### PR TITLE
No dependencies

### DIFF
--- a/readme.MD
+++ b/readme.MD
@@ -23,7 +23,7 @@ In either case, you can override the default port by passing in your own at the 
 The server has 2 parameters:
 
 - `url={string}` - the url you want to proxy
-- `json={boolean}` - (optional) will force the response to be in JSON format. For the rare occasion when you're dealing with a site that returns JSON, but doesn't bother to set the proper `content-type` header.
+- `contentType={string}` - (optional) will override the response to be in whatever format you want without altering the body. This is for really weird edge cases where you're dealing with old/inept servers that might be serving up something like JSON or XML, but return it as `Content-Type: text/plain`
 
 ## HTTP Verb
 
@@ -35,12 +35,12 @@ The server transparently passes all headers to the destination. Useful for authe
 
 ## Examples
 
-http://localhost:1234/?q=https://baconipsum.com/api/?type=meat-and-filler
+http://localhost:1234/?url=https://baconipsum.com/api/?type=meat-and-filler
 
-http://localhost:1234/?q=https://google.com
+http://localhost:1234/?url=https://google.com
 
-http://localhost:1234/?q=https://google.com&json=true
+http://localhost:1234/?url=https://google.com&contentType=application/json
 
 ## Security
 
-Note that this disables TLS certificate validation on all proxied requests. It's done intentionally for local development. You would never use something like this in production.
+Note that this disables TLS certificate validation on all proxied requests. It's done intentionally for local development. You would never use something like this for production.

--- a/server.js
+++ b/server.js
@@ -24,7 +24,7 @@ const server = http.createServer((req, res) => {
 
   const reqUrl = new URL(req.url, `http://localhost:${PORT}`);
   const targetUrl = reqUrl.searchParams.get('url') || '';
-  const forceJson = reqUrl.searchParams.get('json') || 'false';
+  const contentTypeOverride = reqUrl.searchParams.get('contentType') || '';
 
   if (!targetUrl) {
     res.writeHead(400, { ...CORS_HEADERS, 'Content-Type': 'text/plain' });
@@ -40,8 +40,6 @@ const server = http.createServer((req, res) => {
     res.end('Invalid target URL');
     return;
   }
-
-  const forceJsonFlag = forceJson.toLowerCase() === 'true';
 
   // Forward headers but drop host so the target sees its own hostname
   const forwardHeaders = Object.assign({}, req.headers);
@@ -65,9 +63,7 @@ const server = http.createServer((req, res) => {
     proxyRes.on('data', (chunk) => chunks.push(chunk));
     proxyRes.on('end', () => {
       const body = Buffer.concat(chunks);
-      const upstreamContentType = proxyRes.headers['content-type'] || 'text/plain';
-      const isJSON = forceJsonFlag || upstreamContentType.includes('json');
-      const contentType = isJSON ? 'application/json' : upstreamContentType;
+      const contentType = contentTypeOverride || proxyRes.headers['content-type'] || 'text/plain';
 
       res.writeHead(proxyRes.statusCode, {
         ...CORS_HEADERS,


### PR DESCRIPTION
Allows return header of `Content-Type` to be overridden